### PR TITLE
Move player logic out of player animator class into appropriate scripts

### DIFF
--- a/Assets/Prefabs/Player/Player.prefab
+++ b/Assets/Prefabs/Player/Player.prefab
@@ -202,9 +202,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: b49b6dad372d5bf41995299f19a5b3ae, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  _animator: {fileID: 1153077121}
   _player: {fileID: 3529117556607379003}
   _playerController: {fileID: 2203771743708642502}
   _weaponRotator: {fileID: 8193374998248468526}
+  _playerHealth: {fileID: 667576100}
   attackClip: {fileID: 7400000, guid: 35e1bf1fc9a9c6e48a2e60cced083e83, type: 2}
 --- !u!1 &1906913165
 GameObject:
@@ -631,6 +633,7 @@ MonoBehaviour:
     m_Bits: 1024
   maxRollSpeed: 25
   rollSpeedDecay: 10
+  deadPlayer: {fileID: 737039020340058576, guid: 9b2fa77dcdd63444ba2cfbbaf76dfb80, type: 3}
 --- !u!114 &1926073866
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Player/Player.prefab
+++ b/Assets/Prefabs/Player/Player.prefab
@@ -205,9 +205,8 @@ MonoBehaviour:
   _animator: {fileID: 1153077121}
   _player: {fileID: 3529117556607379003}
   _playerController: {fileID: 2203771743708642502}
-  _weaponRotator: {fileID: 8193374998248468526}
+  _weapon: {fileID: 1908588099}
   _playerHealth: {fileID: 667576100}
-  attackClip: {fileID: 7400000, guid: 35e1bf1fc9a9c6e48a2e60cced083e83, type: 2}
 --- !u!1 &1906913165
 GameObject:
   m_ObjectHideFlags: 0
@@ -461,6 +460,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f4c1abc92d3def34d8185e55012b561a, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  _hitBox: {fileID: 1908588098}
+  _playerController: {fileID: 2203771743708642502}
+  _weaponRotator: {fileID: 8193374998248468526}
+  _attackClip: {fileID: 7400000, guid: 35e1bf1fc9a9c6e48a2e60cced083e83, type: 2}
+  _attackDuration: 0.3
 --- !u!1 &2203771743708642508
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/_Scripts/Characters/Enemy Refactor/Character.cs
+++ b/Assets/_Scripts/Characters/Enemy Refactor/Character.cs
@@ -19,7 +19,7 @@ namespace GMTK2022
             walkVector = Vector2.zero;
         }
 
-        protected void OnDirectionRecieved(Vector2 movementDir) {
+        protected virtual void OnMoveDirectionRecieved(Vector2 movementDir) {
             walkVector = movementDir * movementSpeed;
         }
 

--- a/Assets/_Scripts/Characters/Enemy Refactor/Enemy.cs
+++ b/Assets/_Scripts/Characters/Enemy Refactor/Enemy.cs
@@ -34,7 +34,7 @@ namespace GMTK2022
         }
 
         private void OnDisable() {
-            enemyController.onMove2Target -= OnDirectionRecieved;
+            enemyController.onMove2Target -= OnMoveDirectionRecieved;
             enemyController.onShoot2Target -= OnShootAtTarget;
             enemyController.onRotate2Target -= OnTargetUpdate;
         }

--- a/Assets/_Scripts/Characters/Enemy Refactor/Enemy.cs
+++ b/Assets/_Scripts/Characters/Enemy Refactor/Enemy.cs
@@ -26,7 +26,7 @@ namespace GMTK2022
             }
             enemyController = GetComponent<EnemyController>();
 
-            enemyController.onMove2Target += OnDirectionRecieved;
+            enemyController.onMove2Target += OnMoveDirectionRecieved;
             enemyController.onShoot2Target += OnShootAtTarget;
             enemyController.onRotate2Target += OnTargetUpdate;
         }

--- a/Assets/_Scripts/Characters/Enemy Refactor/Player.cs
+++ b/Assets/_Scripts/Characters/Enemy Refactor/Player.cs
@@ -17,8 +17,12 @@ namespace GMTK2022
 
 
         private PlayerController playerController;
+        private Vector2 _lastMovementDirection = Vector2.zero;
         private float currentRollSpeed;
         private Vector3 currentRollDir;
+
+        public event Action<Vector2> OnIdle;
+        public event Action<Vector2> OnWalk;
         public event Action<Vector2> OnRoll;
         public event Action<Vector2> OnRollEnd;
 
@@ -42,17 +46,26 @@ namespace GMTK2022
         }
 
         private void OnEnable() {
-            playerController.onMovementInput += OnDirectionRecieved;
+            playerController.onMovementInput += OnMoveDirectionRecieved;
             playerController.onRollInput += OnRollInputRecieved;
             playerController.onMousePositionUpdate += OnTargetUpdate;
             _playerHealth.onDeath += OnDeath;
         }
 
         private void OnDisable() {
-            playerController.onMovementInput -= OnDirectionRecieved;
+            playerController.onMovementInput -= OnMoveDirectionRecieved;
             playerController.onRollInput -= OnRollInputRecieved;
             playerController.onMousePositionUpdate -= OnTargetUpdate;
             _playerHealth.onDeath -= OnDeath;
+        }
+
+        protected override void OnMoveDirectionRecieved(Vector2 movementDir) {
+            base.OnMoveDirectionRecieved(movementDir);
+            OnWalk?.Invoke(movementDir);
+            if(movementDir == Vector2.zero) {
+                OnIdle?.Invoke(_lastMovementDirection);
+            }
+            _lastMovementDirection = movementDir;
         }
 
         private void OnRollInputRecieved(Vector2 movementDir) {
@@ -85,8 +98,6 @@ namespace GMTK2022
             gManager.GameEnded();
             Destroy(gameObject);
         }
-
-        
 
         private void HandleRolling() {
             debugRollTime += Time.fixedDeltaTime;

--- a/Assets/_Scripts/Characters/PlayerAnimator.cs
+++ b/Assets/_Scripts/Characters/PlayerAnimator.cs
@@ -1,74 +1,66 @@
-using System.Collections;
 using UnityEngine;
-using System;
 
 namespace GMTK2022
 {
     public class PlayerAnimator : MonoBehaviour
     {
-        //That's a large amount of dependencies. May need refactoring.
+        #region Dependencies
+        //That a decent amount of dependencies. May need refactoring.
+
         [SerializeField] private Animator _animator;
         [SerializeField] private Player _player;
-        [SerializeField] private PlayerController _playerController;
         [SerializeField] private Weapon _weapon;
         [SerializeField] private Health _playerHealth;
 
+        #endregion
+
         //May need to use Unity's animator statemachine for transitions
         //rather than tracking everything here and transitioning manually.
-        private Vector2 _lastMovementInput;
-        private bool _isRolling;
-        private bool _isAttacking;
         private bool _isDead;
+        private bool _isAttacking;
+        private bool _isRolling;
+        private bool _isWalking;
 
         private void Awake() {
             ResetStates();
         }
 
-        public void ResetStates() {
-            _lastMovementInput = Vector2.zero;
-            _isRolling = false;
-            _isAttacking = false;
-            _isDead = false;
-        }
-
         private void OnEnable() {
-            _playerController.onMovementInput += UpdateMovementVector;
+            _playerHealth.onDeath += DeathTriggered;
             _weapon.OnAttackStart += AttackStarted;
             _weapon.OnAttackEnd += AttackComplete;
             _player.OnRoll += RollingStarted;
             _player.OnRollEnd += RollingComplete;
-            _playerHealth.onDeath += DeathTriggered;
+            _player.OnWalk += UpdateWalkVector;
+            _player.OnIdle += IdleStarted;
         }
 
         private void OnDisable() {
-            _playerController.onMovementInput -= UpdateMovementVector;
+            _playerHealth.onDeath -= DeathTriggered;
             _weapon.OnAttackStart -= AttackStarted;
             _weapon.OnAttackEnd -= AttackComplete;
             _player.OnRoll -= RollingStarted;
             _player.OnRollEnd -= RollingComplete;
-            _playerHealth.onDeath -= DeathTriggered;
+            _player.OnWalk -= UpdateWalkVector;
+            _player.OnIdle -= IdleStarted;
         }
 
         private void Update() {
-            var state = GetState();
-
-            if(state == _currentState) return;
-            _animator.CrossFade(state, 0, 0);
-            _currentState = state;
+            StateMachineUpdate();
         }
 
-        private void UpdateMovementVector(Vector2 direction) {
-            if(direction == Vector2.zero) {
-                _animator.SetFloat("idleX", _lastMovementInput.x);
-                _animator.SetFloat("idleY", _lastMovementInput.y);
-                _lastMovementInput = direction;
+        private void DeathTriggered() {
+            _isDead = true;
+        }
 
-                return;
-            }
-            _lastMovementInput = direction;
+        private void AttackStarted(Vector2 direction) {
+            _isAttacking = true;
+            _animator.SetFloat("attackX", direction.x);
+            _animator.SetFloat("attackY", direction.y);
+        }
 
-            _animator.SetFloat("movementX", direction.x);
-            _animator.SetFloat("movementY", direction.y);
+        private void AttackComplete() {
+            _isAttacking = false;
         }
 
         private void RollingStarted(Vector2 direction) {
@@ -81,39 +73,52 @@ namespace GMTK2022
             _isRolling = false;
         }
 
-        private void AttackStarted(Vector2 direction) 
-        {
-            _isAttacking = true;
-            _animator.SetFloat("attackX", direction.x);
-            _animator.SetFloat("attackY", direction.y);
+        private void UpdateWalkVector(Vector2 direction) {
+            _isWalking = direction != Vector2.zero;
+            _animator.SetFloat("movementX", direction.x);
+            _animator.SetFloat("movementY", direction.y);
         }
 
-        private void AttackComplete() {
+        private void IdleStarted(Vector2 direction) {
+            _animator.SetFloat("idleX", direction.x);
+            _animator.SetFloat("idleY", direction.y);
+        }
+
+        #region Pseudo State Machine
+        //This way of handling animation states was influned by Tarodev
+
+        public void ResetStates() {
+            _isRolling = false;
             _isAttacking = false;
+            _isDead = false;
+            _isWalking = false;
         }
 
-        private void DeathTriggered() {
-            _isDead = true;
-        }
-                
         private int GetState() {
             //Highest priority checked first
             if(_isDead) return Dead;
             if(_isAttacking) return Attack;
             if(_isRolling) return Roll;
-            return _lastMovementInput == Vector2.zero ? Idle : Walk;
+            if(_isWalking) return Walk;
+            return Idle;
         }
 
-        #region Cached Properties
-        //This way of handling animation states was influned by Tarodev
+        private void StateMachineUpdate() {
+            var state = GetState();
+
+            if(state == _currentState) return;
+            _animator.CrossFade(state, 0, 0);
+            _currentState = state;
+        }
+
 
         private int _currentState;
 
-        private static readonly int Idle = Animator.StringToHash("Idle Blend Tree");
-        private static readonly int Walk = Animator.StringToHash("Walk Blend Tree");
-        private static readonly int Roll = Animator.StringToHash("Roll Blend Tree");
-        private static readonly int Attack = Animator.StringToHash("Attack Blend Tree");
         private static readonly int Dead = Animator.StringToHash("Death");
+        private static readonly int Attack = Animator.StringToHash("Attack Blend Tree");
+        private static readonly int Roll = Animator.StringToHash("Roll Blend Tree");
+        private static readonly int Walk = Animator.StringToHash("Walk Blend Tree");
+        private static readonly int Idle = Animator.StringToHash("Idle Blend Tree");
 
         #endregion
     }

--- a/Assets/_Scripts/Game/GameplayManager.cs
+++ b/Assets/_Scripts/Game/GameplayManager.cs
@@ -122,6 +122,7 @@ namespace GMTK2022
             }
             else if(scoreBoard == null)
             {
+                //TODO: Fix null ref after gameover
                 scoreBoard = GameObject.Find("ScoreBoard").GetComponent<TextMeshProUGUI>();
                 
             }


### PR DESCRIPTION
There were several pieces of logic that should not exist within the player animator script. The animator script is for handling animation states and not calculating vectors, mouse positions, and trigger death events. This PR moves that logic into the appropriate scripts.