### PR TITLE
Fix null reference regarding game score and refactor game state transitions

### DIFF
--- a/Assets/Game/GameState.asset
+++ b/Assets/Game/GameState.asset
@@ -1,0 +1,15 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d32c4d140e8bb67419bc3c462611793b, type: 3}
+  m_Name: GameState
+  m_EditorClassIdentifier: 
+  _currentState: 0

--- a/Assets/Game/GameState.asset.meta
+++ b/Assets/Game/GameState.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 44244485fd61a9a47a093fed9340a0cb
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Game/Score.asset
+++ b/Assets/Game/Score.asset
@@ -1,0 +1,15 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 404e83d6616f51a42ab4a3d70ae22e79, type: 3}
+  m_Name: Score
+  m_EditorClassIdentifier: 
+  _score: 0

--- a/Assets/Game/Score.asset.meta
+++ b/Assets/Game/Score.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a254b246253248543bb12015a4773ad2
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/Enemy/Enemy.prefab
+++ b/Assets/Prefabs/Enemy/Enemy.prefab
@@ -160,6 +160,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   movementSpeed: 2
   enemyValue: 1
+  _scoreSO: {fileID: 11400000, guid: a254b246253248543bb12015a4773ad2, type: 2}
 --- !u!114 &945816611267811947
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Playfield/DisplayCanvas.prefab
+++ b/Assets/Prefabs/Playfield/DisplayCanvas.prefab
@@ -229,8 +229,9 @@ GameObject:
   - component: {fileID: 8089912552283865612}
   - component: {fileID: 2392125921739442760}
   - component: {fileID: 6264540958835617023}
+  - component: {fileID: 6444107694040990045}
   m_Layer: 0
-  m_Name: Panel
+  m_Name: ScoreDisplay
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -248,6 +249,7 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
+  - {fileID: 273538814869130933}
   - {fileID: 6443865664946767804}
   m_Father: {fileID: 2494814264067792059}
   m_RootOrder: 1
@@ -295,6 +297,21 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
+--- !u!114 &6444107694040990045
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7182283170351115239}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c7936e2f41fc5c24681cd7f88512da17, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _scoreSO: {fileID: 11400000, guid: a254b246253248543bb12015a4773ad2, type: 2}
+  _scoreTextMesh: {fileID: 9101567206546009012}
+  _maxStringSize: 5
 --- !u!1 &7376836248687365425
 GameObject:
   m_ObjectHideFlags: 0
@@ -473,6 +490,141 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
+--- !u!1 &8721216783177692044
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 273538814869130933}
+  - component: {fileID: 1309689897610658463}
+  - component: {fileID: 353247503606083956}
+  m_Layer: 0
+  m_Name: ScoreLabel
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &273538814869130933
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8721216783177692044}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 8089912552283865612}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0.5}
+  m_AnchorMax: {x: 0, y: 0.5}
+  m_AnchoredPosition: {x: 45.800026, y: 0}
+  m_SizeDelta: {x: 91.6, y: 36}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &1309689897610658463
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8721216783177692044}
+  m_CullTransparentMesh: 1
+--- !u!114 &353247503606083956
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8721216783177692044}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: 'Score:'
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 1
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 0.990566, g: 0.53881115, b: 0.023362402, a: 1}
+    topRight: {r: 0.7924528, g: 0.38916326, b: 0, a: 1}
+    bottomLeft: {r: 0.4716981, g: 0.077874675, b: 0.077874675, a: 1}
+    bottomRight: {r: 0.7264151, g: 0.08566215, b: 0.14949967, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 30
+  m_fontSizeBase: 30
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 4
+  m_VerticalAlignment: 256
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
 --- !u!1 &8800721792275118947
 GameObject:
   m_ObjectHideFlags: 0
@@ -504,12 +656,12 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 8089912552283865612}
-  m_RootOrder: 0
+  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0.010070801, y: -1.1400146}
-  m_SizeDelta: {x: 200, y: 50}
+  m_AnchorMin: {x: 1, y: 0.5}
+  m_AnchorMax: {x: 1, y: 0.5}
+  m_AnchoredPosition: {x: -48.973007, y: 0}
+  m_SizeDelta: {x: 97.946, y: 36}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &772489164162584346
 CanvasRenderer:
@@ -539,9 +691,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: 'Score
-
-'
+  m_text: 00000
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
   m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
@@ -568,14 +718,14 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 34
-  m_fontSizeBase: 34
+  m_fontSize: 30
+  m_fontSizeBase: 30
   m_fontWeight: 400
   m_enableAutoSizing: 0
   m_fontSizeMin: 18
   m_fontSizeMax: 72
   m_fontStyle: 1
-  m_HorizontalAlignment: 2
+  m_HorizontalAlignment: 1
   m_VerticalAlignment: 512
   m_textAlignment: 65535
   m_characterSpacing: 0

--- a/Assets/Prefabs/Playfield/GameplayManager.prefab
+++ b/Assets/Prefabs/Playfield/GameplayManager.prefab
@@ -25,7 +25,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 5232755913310062953}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 414.3615, y: 139.94978, z: -1.2948928}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -44,4 +44,5 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 39c4fc0b4900dc74d8543d6bbfeab124, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  scoreBoard: {fileID: 0}
+  _gameStateSO: {fileID: 11400000, guid: 44244485fd61a9a47a093fed9340a0cb, type: 2}
+  _scoreSO: {fileID: 11400000, guid: a254b246253248543bb12015a4773ad2, type: 2}

--- a/Assets/Scenes/DefaultLevel.unity
+++ b/Assets/Scenes/DefaultLevel.unity
@@ -245,17 +245,6 @@ MonoBehaviour:
   m_MaximumFOV: 60
   m_MinimumOrthoSize: 1
   m_MaximumOrthoSize: 5000
---- !u!114 &46420789 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 9101567206546009012, guid: 0f29aae473809b34b8e92fa8fab5e7d2, type: 3}
-  m_PrefabInstance: {fileID: 1482177112}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!4 &134223599 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 2203771743708642509, guid: 9d0c47c1543903d4ebec180c05432613, type: 3}
@@ -555,65 +544,25 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
-    - target: {fileID: 234921687941571831, guid: 41e80be46749fd9439c219516f3ff60e, type: 3}
-      propertyPath: m_IsActive
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1231909916512968416, guid: 41e80be46749fd9439c219516f3ff60e, type: 3}
-      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Target
-      value: 
-      objectReference: {fileID: 0}
-    - target: {fileID: 1701990648592371761, guid: 41e80be46749fd9439c219516f3ff60e, type: 3}
-      propertyPath: m_Enabled
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3494668854403234179, guid: 41e80be46749fd9439c219516f3ff60e, type: 3}
-      propertyPath: m_Camera
-      value: 
-      objectReference: {fileID: 956851595}
-    - target: {fileID: 3731557460361080690, guid: 41e80be46749fd9439c219516f3ff60e, type: 3}
-      propertyPath: m_Value
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4643496643650304779, guid: 41e80be46749fd9439c219516f3ff60e, type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0.68270874
-      objectReference: {fileID: 0}
-    - target: {fileID: 4643496643650304779, guid: 41e80be46749fd9439c219516f3ff60e, type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 3.044201
-      objectReference: {fileID: 0}
-    - target: {fileID: 5052501888624554510, guid: 41e80be46749fd9439c219516f3ff60e, type: 3}
-      propertyPath: _playerController
-      value: 
-      objectReference: {fileID: 667576104}
     - target: {fileID: 5232755913310062953, guid: 41e80be46749fd9439c219516f3ff60e, type: 3}
       propertyPath: m_Name
       value: GameplayManager
       objectReference: {fileID: 0}
-    - target: {fileID: 5232755913310062954, guid: 41e80be46749fd9439c219516f3ff60e, type: 3}
-      propertyPath: scoreBoard
-      value: 
-      objectReference: {fileID: 46420789}
-    - target: {fileID: 5232755913310062954, guid: 41e80be46749fd9439c219516f3ff60e, type: 3}
-      propertyPath: _gameStateSO
-      value: 
-      objectReference: {fileID: 11400000, guid: 44244485fd61a9a47a093fed9340a0cb, type: 2}
     - target: {fileID: 5232755913310062955, guid: 41e80be46749fd9439c219516f3ff60e, type: 3}
       propertyPath: m_RootOrder
       value: 7
       objectReference: {fileID: 0}
     - target: {fileID: 5232755913310062955, guid: 41e80be46749fd9439c219516f3ff60e, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 414.3615
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5232755913310062955, guid: 41e80be46749fd9439c219516f3ff60e, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 139.94978
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5232755913310062955, guid: 41e80be46749fd9439c219516f3ff60e, type: 3}
       propertyPath: m_LocalPosition.z
-      value: -1.2948928
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5232755913310062955, guid: 41e80be46749fd9439c219516f3ff60e, type: 3}
       propertyPath: m_LocalRotation.w
@@ -642,38 +591,6 @@ PrefabInstance:
     - target: {fileID: 5232755913310062955, guid: 41e80be46749fd9439c219516f3ff60e, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6496259753810551895, guid: 41e80be46749fd9439c219516f3ff60e, type: 3}
-      propertyPath: m_SizeDelta.x
-      value: -1108.0001
-      objectReference: {fileID: 0}
-    - target: {fileID: 6496259753810551895, guid: 41e80be46749fd9439c219516f3ff60e, type: 3}
-      propertyPath: m_SizeDelta.y
-      value: -251.20001
-      objectReference: {fileID: 0}
-    - target: {fileID: 6496259753810551895, guid: 41e80be46749fd9439c219516f3ff60e, type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: -535.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 6496259753810551895, guid: 41e80be46749fd9439c219516f3ff60e, type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 135.1
-      objectReference: {fileID: 0}
-    - target: {fileID: 6983324736270245004, guid: 41e80be46749fd9439c219516f3ff60e, type: 3}
-      propertyPath: healthToDisplay
-      value: 
-      objectReference: {fileID: 667576100}
-    - target: {fileID: 7511602551886849524, guid: 41e80be46749fd9439c219516f3ff60e, type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7511602551886849524, guid: 41e80be46749fd9439c219516f3ff60e, type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8261067306801395453, guid: 41e80be46749fd9439c219516f3ff60e, type: 3}
-      propertyPath: m_RootOrder
-      value: 1
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 41e80be46749fd9439c219516f3ff60e, type: 3}
@@ -1050,11 +967,6 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 6
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!20 &956851595 stripped
-Camera:
-  m_CorrespondingSourceObject: {fileID: 601852754432983719, guid: 69c48823744e78b42ad54881159b7fc3, type: 3}
-  m_PrefabInstance: {fileID: 36971817}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1341911104
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/DefaultLevel.unity
+++ b/Assets/Scenes/DefaultLevel.unity
@@ -136,11 +136,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 601852754432983712, guid: 69c48823744e78b42ad54881159b7fc3, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 18.33191
+      value: 20.89
       objectReference: {fileID: 0}
     - target: {fileID: 601852754432983712, guid: 69c48823744e78b42ad54881159b7fc3, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 10.600002
+      value: 10.6
       objectReference: {fileID: 0}
     - target: {fileID: 601852754432983712, guid: 69c48823744e78b42ad54881159b7fc3, type: 3}
       propertyPath: m_LocalPosition.z
@@ -534,6 +534,14 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 1568772892950129220, guid: c5b3375dc9134974aae1cdc7108ac66d, type: 3}
+      propertyPath: _gameStateSO
+      value: 
+      objectReference: {fileID: 11400000, guid: 44244485fd61a9a47a093fed9340a0cb, type: 2}
+    - target: {fileID: 1568772892950129220, guid: c5b3375dc9134974aae1cdc7108ac66d, type: 3}
+      propertyPath: _playerController
+      value: 
+      objectReference: {fileID: 667576104}
     - target: {fileID: 1568772892950129221, guid: c5b3375dc9134974aae1cdc7108ac66d, type: 3}
       propertyPath: m_Name
       value: PauseManager
@@ -587,6 +595,10 @@ PrefabInstance:
       propertyPath: scoreBoard
       value: 
       objectReference: {fileID: 46420789}
+    - target: {fileID: 5232755913310062954, guid: 41e80be46749fd9439c219516f3ff60e, type: 3}
+      propertyPath: _gameStateSO
+      value: 
+      objectReference: {fileID: 11400000, guid: 44244485fd61a9a47a093fed9340a0cb, type: 2}
     - target: {fileID: 5232755913310062955, guid: 41e80be46749fd9439c219516f3ff60e, type: 3}
       propertyPath: m_RootOrder
       value: 7

--- a/Assets/_Scripts/Characters/Enemy Refactor/Enemy.cs
+++ b/Assets/_Scripts/Characters/Enemy Refactor/Enemy.cs
@@ -1,4 +1,3 @@
-using System.Collections;
 using UnityEngine;
 
 namespace GMTK2022
@@ -8,7 +7,7 @@ namespace GMTK2022
     {
         [SerializeField]
         private int enemyValue = 1;
-        
+        [SerializeField] ScoreSO _scoreSO;
 
         private Shooter shooter;
         private EnemyController enemyController;
@@ -20,10 +19,6 @@ namespace GMTK2022
             base.Awake();
             shooter = GetComponentInChildren<Shooter>();
             eHealth = GetComponent<Health>();
-            if (eHealth)
-            {
-                eHealth.onDeath += Die;
-            }
             enemyController = GetComponent<EnemyController>();     
         }
 
@@ -31,12 +26,14 @@ namespace GMTK2022
             enemyController.onMove2Target += OnMoveDirectionRecieved;
             enemyController.onShoot2Target += OnShootAtTarget;
             enemyController.onRotate2Target += OnTargetUpdate;
+            eHealth.onDeath += Die;
         }
 
         private void OnDisable() {
             enemyController.onMove2Target -= OnMoveDirectionRecieved;
             enemyController.onShoot2Target -= OnShootAtTarget;
             enemyController.onRotate2Target -= OnTargetUpdate;
+            eHealth.onDeath -= Die;
         }
 
         private void OnShootAtTarget(Vector2 targetPos2D) {
@@ -66,16 +63,8 @@ namespace GMTK2022
         public void Die()
         {
             isDead = true;    
+            _scoreSO.AddScore(enemyValue);
             StartCoroutine(GetComponent<EnemyAnimator>().PlayDeathAnimationAndDestroy());  
-            eHealth.onDeath -= Die;
-            
-        }
-
-        
-        
-
-        private void OnDestroy() {
-            GameplayManager.instance.AddScore(enemyValue);
         }
     }
 }

--- a/Assets/_Scripts/Characters/Enemy Refactor/Player.cs
+++ b/Assets/_Scripts/Characters/Enemy Refactor/Player.cs
@@ -95,7 +95,7 @@ namespace GMTK2022
             {
             Instantiate(deadPlayer, transform.position, Quaternion.identity);
             }
-            gManager.GameEnded();
+            gManager.GameOver();
             Destroy(gameObject);
         }
 

--- a/Assets/_Scripts/Game/GameStateSO.cs
+++ b/Assets/_Scripts/Game/GameStateSO.cs
@@ -32,11 +32,7 @@ namespace GMTK2022
         public event Action OnGameResume;
         public event Action OnGameOver;
 
-        private void OnEnable() {
-            Init();
-        }
-
-        public void Init() {
+        public void ResetGameState() {
             _currentState = GameState.Initializing;
         }
     }

--- a/Assets/_Scripts/Game/GameStateSO.cs
+++ b/Assets/_Scripts/Game/GameStateSO.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using UnityEngine;
+
+namespace GMTK2022
+{
+    //[CreateAssetMenu(menuName = "GMTK2022/game/game state")]
+    public class GameStateSO : ScriptableObject
+    {
+        [SerializeField] GameState _currentState = GameState.Initializing;
+        public GameState CurrentState => _currentState;
+        public void SwitchToState(GameState gameState) {
+            switch(gameState) {
+                case GameState.Playing:
+                    if(_currentState == GameState.Paused) OnGameResume?.Invoke();
+                    else OnGameStart?.Invoke();
+                    break;
+                case GameState.Paused:
+                    OnGamePause?.Invoke();
+                    break;
+                case GameState.GameOver:
+                    OnGameOver?.Invoke();
+                    break;
+                default:
+                    //do nothing
+                    break;
+            }
+            _currentState = gameState;
+        }
+
+        public event Action OnGameStart;
+        public event Action OnGamePause;
+        public event Action OnGameResume;
+        public event Action OnGameOver;
+
+        private void OnEnable() {
+            Init();
+        }
+
+        public void Init() {
+            _currentState = GameState.Initializing;
+        }
+    }
+
+    public enum GameState
+    {
+        Initializing,
+        Playing,
+        Paused,
+        GameOver
+    }
+}

--- a/Assets/_Scripts/Game/GameStateSO.cs.meta
+++ b/Assets/_Scripts/Game/GameStateSO.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d32c4d140e8bb67419bc3c462611793b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Scripts/Game/GameplayManager.cs
+++ b/Assets/_Scripts/Game/GameplayManager.cs
@@ -71,9 +71,7 @@ namespace GMTK2022
             currentScore += scoreToAdd;
             if(scoreBoard != null) 
             {
-                string score_string = currentScore.ToString();
-                while(score_string.Length < MAX_SCORE_SIZE)
-                    score_string = "0" + score_string;
+                string score_string = currentScore.ToString("D" + MAX_SCORE_SIZE.ToString());
                 scoreBoard.text = "SCORE: " + score_string;
             }
             else if(scoreBoard == null)

--- a/Assets/_Scripts/Game/GameplayManager.cs
+++ b/Assets/_Scripts/Game/GameplayManager.cs
@@ -1,35 +1,20 @@
 using UnityEngine;
-using TMPro;
 using UnityEngine.SceneManagement;
 
 namespace GMTK2022
 {
     public class GameplayManager : MonoBehaviour
     {
-        private const int MAX_SCORE_SIZE = 6;
+        [SerializeField] private GameStateSO _gameStateSO;
+        [SerializeField] private ScoreSO _scoreSO;
 
-        [SerializeField]
-        private GameStateSO _gameStateSO;
-
-        [SerializeField]
-        private TextMeshProUGUI scoreBoard = null;
-
-        public static GameplayManager instance = null;
-
-        private int currentScore = 0;
-
-        private void Awake()
-        {
-            if(FindObjectsOfType<GameplayManager>().Length > 1)
-            {
-                Destroy(gameObject);
-            }
-            if(instance == null)
-                instance = this;
+        private void Awake() {
+            ResetGameData();
         }
 
-        private void Start() {
-            _gameStateSO.Init();
+        private void ResetGameData() {
+            _gameStateSO.ResetGameState();
+            _scoreSO.ResetScore();
         }
 
         private void Update() {
@@ -63,22 +48,8 @@ namespace GMTK2022
             SceneManager.LoadScene(0);
         }
 
-        public void GameEnded() {
+        public void GameOver() {
             _gameStateSO.SwitchToState(GameState.GameOver);
-        }
-
-        public void AddScore(int scoreToAdd) {
-            currentScore += scoreToAdd;
-            if(scoreBoard != null) 
-            {
-                string score_string = currentScore.ToString("D" + MAX_SCORE_SIZE.ToString());
-                scoreBoard.text = "SCORE: " + score_string;
-            }
-            else if(scoreBoard == null)
-            {
-                //TODO: Fix null ref after gameover
-                scoreBoard = GameObject.Find("ScoreBoard").GetComponent<TextMeshProUGUI>();
-            }
         }
     }
 }

--- a/Assets/_Scripts/Game/GameplayManager.cs
+++ b/Assets/_Scripts/Game/GameplayManager.cs
@@ -1,6 +1,5 @@
 using UnityEngine;
 using TMPro;
-using System;
 using UnityEngine.SceneManagement;
 
 namespace GMTK2022
@@ -10,21 +9,12 @@ namespace GMTK2022
         private const int MAX_SCORE_SIZE = 6;
 
         [SerializeField]
+        private GameStateSO _gameStateSO;
+
+        [SerializeField]
         private TextMeshProUGUI scoreBoard = null;
-        
-        
 
         public static GameplayManager instance = null;
-        public static event Action onPauseRequest;
-        public static event Action onGameEndRequest;
-
-        GameState gameState;
-        enum GameState
-        {
-            Pause,
-            Play,
-            Dead
-        }
 
         private int currentScore = 0;
 
@@ -36,67 +26,35 @@ namespace GMTK2022
             }
             if(instance == null)
                 instance = this;
-            DontDestroyOnLoad(gameObject);
         }
 
         private void Start() {
-            SwitchStateTo(GameState.Play);
+            _gameStateSO.Init();
         }
 
         private void Update() {
-            switch(gameState) {
-                case GameState.Pause:
-                    if(Input.GetKeyDown(KeyCode.Escape)) {
-
-                        SwitchStateTo(GameState.Play);
-                    }
-                    break;
-                case GameState.Play:
-                    if(Input.GetKeyDown(KeyCode.Escape)) {
-
-                        SwitchStateTo(GameState.Pause);
-                    }
-                    break;
-                case GameState.Dead:
-                    // if(Input.anyKey) {
-                    //     ResetLevel();
-                    //     SwitchStateTo(GameState.Play);
-                    // }
-                    break;
-            }
+            HandleGameStateTransitions();
         }
 
-        private void SwitchStateTo(GameState state) {
-            gameState = state;
-            switch(gameState) {
-                case GameState.Pause:
-                onPauseRequest?.Invoke();
-                    
-
-
+        private void HandleGameStateTransitions() {
+            switch(_gameStateSO.CurrentState) {
+                case GameState.Initializing:
+                    _gameStateSO.SwitchToState(GameState.Playing);
                     break;
-                case GameState.Play:
-                    if(PauseManager.isPaused) {
-                        onPauseRequest?.Invoke();
+                case GameState.Paused:
+                    if(Input.GetKeyDown(KeyCode.Escape)) {
+                        _gameStateSO.SwitchToState(GameState.Playing);
                     }
-
-
                     break;
-                case GameState.Dead:
-                    if(PauseManager.isPaused) {
-                        onPauseRequest?.Invoke();
+                case GameState.Playing:
+                    if(Input.GetKeyDown(KeyCode.Escape)) {
+                        _gameStateSO.SwitchToState(GameState.Paused);
                     }
-                    onGameEndRequest?.Invoke();
-                    if(Input.anyKey)
-                    {
-                        
-                        SwitchStateTo(GameState.Play);
+                    break;
+                case GameState.GameOver:
+                    if(Input.anyKeyDown) {
                         ResetLevel();
                     }
-                    
-                    
-
-
                     break;
             }
         }
@@ -105,10 +63,8 @@ namespace GMTK2022
             SceneManager.LoadScene(0);
         }
 
-
-        public void GameEnded() {                     
-           
-            SwitchStateTo(GameState.Dead);
+        public void GameEnded() {
+            _gameStateSO.SwitchToState(GameState.GameOver);
         }
 
         public void AddScore(int scoreToAdd) {
@@ -124,11 +80,7 @@ namespace GMTK2022
             {
                 //TODO: Fix null ref after gameover
                 scoreBoard = GameObject.Find("ScoreBoard").GetComponent<TextMeshProUGUI>();
-                
             }
         }
-
-        
-        
     }
 }

--- a/Assets/_Scripts/Game/ScoreSO.cs
+++ b/Assets/_Scripts/Game/ScoreSO.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using UnityEngine;
+
+namespace GMTK2022
+{
+    //[CreateAssetMenu(menuName = "GMTK2022/game/score")]
+    public class ScoreSO : ScriptableObject
+    {
+        [SerializeField] int _score = 0;
+        public int Score => _score;
+
+        public event Action<int> OnScoreChanged;
+
+        public void AddScore(int amount) {
+            _score += amount;
+            OnScoreChanged?.Invoke(_score);
+        }
+
+        public void ResetScore() {
+            _score = 0;
+        }
+    }
+}

--- a/Assets/_Scripts/Game/ScoreSO.cs.meta
+++ b/Assets/_Scripts/Game/ScoreSO.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 404e83d6616f51a42ab4a3d70ae22e79
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Scripts/Helpers/PauseManager.cs
+++ b/Assets/_Scripts/Helpers/PauseManager.cs
@@ -7,39 +7,44 @@ namespace GMTK2022
         [SerializeField] Canvas pauseUICanvas;
         [SerializeField] Canvas gameEndCanvas;
         [SerializeField] private PlayerController _playerController;
+        [SerializeField] private GameStateSO _gameStateSO;
         
-        public static bool isPaused = false;
+        private bool _isPaused = false;
 
-        void Awake() {
-            
+        private void Start() {
             pauseUICanvas.gameObject.SetActive(false);
             gameEndCanvas.gameObject.SetActive(false);
-            GameplayManager.onPauseRequest+=Pause;
-            GameplayManager.onGameEndRequest+=GameEnded;
         }
 
-        public void Pause() {
-            if(!isPaused) {
-                isPaused = true;
-                pauseUICanvas.gameObject.SetActive(true);
-                Time.timeScale = 0;
-                _playerController.enabled = false;
-            } else if(isPaused) {
-                isPaused = false;
-                pauseUICanvas.gameObject.SetActive(false);
-                Time.timeScale = 1;
-                _playerController.enabled = true;
-            }
+        private void OnEnable() {
+            _gameStateSO.OnGamePause += Pause;
+            _gameStateSO.OnGameResume += Resume;
+            _gameStateSO.OnGameOver += GameEnded;
         }
 
-        public void GameEnded()
+        private void OnDisable() {
+            _gameStateSO.OnGamePause -= Pause;
+            _gameStateSO.OnGameResume -= Resume;
+            _gameStateSO.OnGameOver -= GameEnded;
+        }
+
+        private void Pause() {
+            _isPaused = true;
+            pauseUICanvas.gameObject.SetActive(true);
+            Time.timeScale = 0;
+            _playerController.enabled = false;
+        }
+
+        private void Resume() {
+            _isPaused = false;
+            pauseUICanvas.gameObject.SetActive(false);
+            Time.timeScale = 1;
+            _playerController.enabled = true;
+        }
+
+        private void GameEnded()
         {
             gameEndCanvas.gameObject.SetActive(true);
         }
-        private void OnDestroy() {
-            GameplayManager.onPauseRequest -= Pause;
-            GameplayManager.onGameEndRequest -= GameEnded;
-        }
-
     }
 }

--- a/Assets/_Scripts/Helpers/PauseManager.cs
+++ b/Assets/_Scripts/Helpers/PauseManager.cs
@@ -8,8 +8,6 @@ namespace GMTK2022
         [SerializeField] Canvas gameEndCanvas;
         [SerializeField] private PlayerController _playerController;
         [SerializeField] private GameStateSO _gameStateSO;
-        
-        private bool _isPaused = false;
 
         private void Start() {
             pauseUICanvas.gameObject.SetActive(false);
@@ -29,14 +27,12 @@ namespace GMTK2022
         }
 
         private void Pause() {
-            _isPaused = true;
             pauseUICanvas.gameObject.SetActive(true);
             Time.timeScale = 0;
             _playerController.enabled = false;
         }
 
         private void Resume() {
-            _isPaused = false;
             pauseUICanvas.gameObject.SetActive(false);
             Time.timeScale = 1;
             _playerController.enabled = true;

--- a/Assets/_Scripts/UI/ScoreManager.cs
+++ b/Assets/_Scripts/UI/ScoreManager.cs
@@ -5,7 +5,6 @@ namespace GMTK2022
 {
     public class ScoreManager : MonoBehaviour
     {
-
         public int score;
         private Text ScoreText;
 

--- a/Assets/_Scripts/UI/ScoreUI.cs
+++ b/Assets/_Scripts/UI/ScoreUI.cs
@@ -1,0 +1,25 @@
+﻿using TMPro;
+using UnityEngine;
+
+namespace GMTK2022
+{
+    public class ScoreUI : MonoBehaviour
+    {
+        [SerializeField] private ScoreSO _scoreSO;
+        [SerializeField] private TextMeshProUGUI _scoreTextMesh;
+        [SerializeField] private int _maxStringSize = 5;
+
+        private void OnEnable() {
+            UpdateScoreText(_scoreSO.Score);
+            _scoreSO.OnScoreChanged += UpdateScoreText;
+        }
+
+        private void OnDisable() {
+            _scoreSO.OnScoreChanged -= UpdateScoreText;
+        }
+
+        private void UpdateScoreText(int score) {
+            _scoreTextMesh.text = score.ToString("D" + _maxStringSize.ToString());
+        }
+    }
+}

--- a/Assets/_Scripts/UI/ScoreUI.cs.meta
+++ b/Assets/_Scripts/UI/ScoreUI.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c7936e2f41fc5c24681cd7f88512da17
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
There was an error pushed to the development branch at some point. It involved a null reference to the score UI text when changing from/to the gameplay scene. This PR fixes that error by extracting the score into a scriptable object and having a score UI script reference it. The score text is then updated via an event trigger.

Also refactored the gameplay manager by extracting the game state into an scriptable object with several events to trigger for various game state transitions. This makes it easy for other scripts to plug into their events and handle the state transitions accordingly. In order for this change to be made, the pause manager had to be refactored slightly.